### PR TITLE
Disable wrapping of tiles

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -88,7 +88,7 @@ function createTileLayer() {
     // latLngBounds
     maxNativeZoom: 7,
     minNativeZoom: 0,
-    // noWrap: false,
+    noWrap: true,
     // pane
     // className
     // keepBuffer: 2,


### PR DESCRIPTION
It doesn’t look like there’s a way to wrap the markers, since they’re derived from `Layer` and the `noWrap` property is introduced in `GridLayer`. Disabling wrapping in the tile layer is the backwards way of accomplishing the same thing.

Closes #56.