### PR TITLE
Update host in endpoint config for prod

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,7 +12,7 @@ use Mix.Config
 config :kerbal_maps, KerbalMapsWeb.Endpoint,
   http: [port: {:system, "PORT"}],
   # This is critical for ensuring web-sockets properly authorize.
-  url: [host: "localhost", port: {:system, "PORT"}],
+  url: [host: "https://kerbal-maps.finitemonkeys.org", port: {:system, "PORT"}],
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true,
   root: ".",


### PR DESCRIPTION
[error] Could not check origin for Phoenix.Socket transport.

Origin of the request: https://kerbal-maps.finitemonkeys.org

This happens when you are attempting a socket connection to a different host than the one configured in your config/ files.